### PR TITLE
Missing definition

### DIFF
--- a/tv_grab_dvb.c
+++ b/tv_grab_dvb.c
@@ -78,6 +78,8 @@ typedef struct chninfo {
 static struct lookup_table *channelid_table;
 static struct chninfo *channels;
 
+const struct lookup_table languageid_table[];
+
 /* Print usage information. {{{ */
 static void usage() {
   fprintf(stderr, "Usage: %s [-d] [-u] [-c] [-n|m|p] [-s] [-t timeout]\n"


### PR DESCRIPTION
Missing definition of languageid_table in tv_grab_dvb.c caused a linker error.